### PR TITLE
[feat][#83] 급감속/급가속 감지했을 경우 자동으로 Expanded Appearance 가 확장되도록 설정

### DIFF
--- a/DrivePal/Sources/Model/LiveActivity/DriveAttributes.swift
+++ b/DrivePal/Sources/Model/LiveActivity/DriveAttributes.swift
@@ -26,4 +26,5 @@ struct DriveState: Codable, Hashable {
     var timestamp: Int
     var isWarning: Bool
     var motionStatus: MotionStatus
+    var shouldDisplayAlert: Bool
 }

--- a/DrivePal/Sources/Model/LiveActivity/DriveSimulator.swift
+++ b/DrivePal/Sources/Model/LiveActivity/DriveSimulator.swift
@@ -20,6 +20,7 @@ final class DriveSimulator {
     var lockScreenImageName = ""
     var isWarning = false
     var motionStatus = MotionStatus.normal
+    var shouldDisplayAlert = false
     weak var delegate: DriveSimulatorDelegate?
     
     var accelerationData = [ChartData]()
@@ -46,7 +47,7 @@ final class DriveSimulator {
 
     // End the drive by resetting the vars
     func endDrive() -> DriveState {
-        return DriveState(count: 0, progress: 0.0, leadingImageName: .palNormal, trailingImageName: "", expandedImageName: .palNormal, lockScreenImageName: .lockScreen, timestamp: 0, isWarning: false, motionStatus: .normal)
+        return DriveState(count: 0, progress: 0.0, leadingImageName: .palNormal, trailingImageName: "", expandedImageName: .palNormal, lockScreenImageName: .lockScreen, timestamp: 0, isWarning: false, motionStatus: .normal, shouldDisplayAlert: false)
     }
 
     // Reset the drive status to a fresh start
@@ -60,13 +61,14 @@ final class DriveSimulator {
         motionStatus = .normal
         lockScreenImageName = .lockScreen
         isWarning = false
+        shouldDisplayAlert = false
         accelerationData.removeAll()
     }
 
     @objc private func runDriveSimulator() {
         timestamp += 1
         // Tell the delegate to update its state
-        delegate?.updateLiveActivity(driveState: DriveState(count: count, progress: progress, leadingImageName: "\(leadingImageName)\(timestamp % 6 + 1)", trailingImageName: "\(trailingImageName)\(timestamp % 4 + 1)", expandedImageName: "\(expandedImageName)\(timestamp % 6 + 1)", lockScreenImageName: "\(lockScreenImageName)\(timestamp % 6 + 1)", timestamp: timestamp, isWarning: isWarning, motionStatus: motionStatus))
+        delegate?.updateLiveActivity(driveState: DriveState(count: count, progress: progress, leadingImageName: "\(leadingImageName)\(timestamp % 6 + 1)", trailingImageName: "\(trailingImageName)\(timestamp % 4 + 1)", expandedImageName: "\(expandedImageName)\(timestamp % 6 + 1)", lockScreenImageName: "\(lockScreenImageName)\(timestamp % 6 + 1)", timestamp: timestamp, isWarning: isWarning, motionStatus: motionStatus, shouldDisplayAlert: shouldDisplayAlert))
     }
 }
 
@@ -79,6 +81,7 @@ extension DriveSimulator {
         expandedImageName = isSuddenStop ? .warnSignThunder : .warnSignMeteor
         motionStatus = isSuddenStop ? MotionStatus.suddenStop : .suddenAcceleration
         isWarning = true
+        shouldDisplayAlert = true
         accelerationData.append(ChartData(timestamp: .now, accelerationValue: zAcceleration))
     }
     

--- a/DrivePal/Sources/Model/LiveActivity/LiveActivityModel.swift
+++ b/DrivePal/Sources/Model/LiveActivity/LiveActivityModel.swift
@@ -39,7 +39,12 @@ final class LiveActivityModel: ObservableObject, DriveSimulatorDelegate {
         self.currentState = driveState
         let updatedDriveStatus = DriveAttributes.ContentState(driveState: driveState)
         Task {
-            await liveActivity?.update(using: updatedDriveStatus)
+            let alertConfiguration = AlertConfiguration(
+                title: "급감속/급가속주의",
+                body: "경고: \(driveState.count)",
+                sound: .default
+            )
+            await liveActivity?.update(using: updatedDriveStatus, alertConfiguration: driveState.isWarning ? alertConfiguration : nil)
         }
     }
     

--- a/DrivePal/Sources/Model/LiveActivity/LiveActivityModel.swift
+++ b/DrivePal/Sources/Model/LiveActivity/LiveActivityModel.swift
@@ -11,7 +11,7 @@ import ActivityKit
 final class LiveActivityModel: ObservableObject, DriveSimulatorDelegate {
     static let shared = LiveActivityModel()
     
-    @Published var currentState = DriveState(count: 0, progress: 0.0, leadingImageName: .palNormal, trailingImageName: "", expandedImageName: .palNormal, lockScreenImageName: .lockScreen, timestamp: 0, isWarning: false, motionStatus: .normal)
+    @Published var currentState = DriveState(count: 0, progress: 0.0, leadingImageName: .palNormal, trailingImageName: "", expandedImageName: .palNormal, lockScreenImageName: .lockScreen, timestamp: 0, isWarning: false, motionStatus: .normal, shouldDisplayAlert: false)
     var liveActivity: Activity<DriveAttributes>?
     var driveAlreadyStarted = false
     let simulator = DriveSimulator()
@@ -44,7 +44,8 @@ final class LiveActivityModel: ObservableObject, DriveSimulatorDelegate {
                 body: "경고: \(driveState.count)",
                 sound: .default
             )
-            await liveActivity?.update(using: updatedDriveStatus, alertConfiguration: driveState.isWarning ? alertConfiguration : nil)
+            await liveActivity?.update(using: updatedDriveStatus, alertConfiguration: driveState.shouldDisplayAlert ? alertConfiguration : nil)
+            simulator.shouldDisplayAlert = false
         }
     }
     


### PR DESCRIPTION
Closes #83

📣 Assignees와 Labels를 우측에서 추가해 주세요!

# 📢 Description
- 급감속/급가속 감지했을 경우 자동으로 Expanded Appearance 가 확장되도록 설정

# 🔑 Key Changes
### 중심적으로 변화가 있는 부분을 명시해 주세요
- LiveActivityModel에서 liveActivity를 update할 때, AlertConfiguration을 사용하는 코드 추가
- alertConfiguration 사용여부를 결정하는 변수 shouldDisplayAlert를 선언, 한번 alert가 울리면 해당 변수를 false로 변경하여 울리지 않도록 함

# 📸 Screenshots

https://github.com/DeveloperAcademy-POSTECH/MC3-Team15-RockStars/assets/61307199/7ad7ba2c-1e87-4366-899f-4a7e98e7d28a

# 🙏 To Reviewers
코드를 확인해주시길 부탁드립니당 🙏
