### PR TITLE
[feat][#62] 위치 권한 획득 후에 즉시 VelocityView 업데이트 되도록 설정

### DIFF
--- a/DrivePal/Sources/View/DrivingPalView.swift
+++ b/DrivePal/Sources/View/DrivingPalView.swift
@@ -131,7 +131,7 @@ private extension DrivingPalView {
             withAnimation {
                 locationHandler.motionStatus = .normal
             }
-            locationHandler.updateSpeed()
+            locationHandler.updateAuthorization()
             #endif
         }
     }


### PR DESCRIPTION
# 📢 Description
- "lcoationManagerDidChangeAuthorization()" 메서드가 최초 권한 승인시에 불리지 않음
- DrivePalView에서 takingOff를 할 때마다 authorization을 업데이트 하도록 수정

# 📸 Screenshots
| 권한 획득 | 속도뷰 업데이트 |
| ----- | ----- |
| <img width="394" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team15-RockStars/assets/50472122/ca0b92e5-93dc-4881-b235-8696cb3f37ac"> | <img width="393" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team15-RockStars/assets/50472122/55f12f40-1c67-4ff7-be2b-085159f0fbba"> |

https://github.com/DeveloperAcademy-POSTECH/MC3-Team15-RockStars/assets/50472122/32dbc781-e5cd-47a2-9774-d83c99c64188

# 🙏 To Reviewers
- 기다려주셔서 감사합니다.
