### PR TITLE
[hotfix] location 업데이트를 아예 중단하면서 발생하는 버그 해결

### DIFF
--- a/DrivePal.xcodeproj/project.pbxproj
+++ b/DrivePal.xcodeproj/project.pbxproj
@@ -738,7 +738,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = DrivePal/DrivePal.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DrivePal/Preview Content\"";
@@ -770,7 +770,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = pos.academy.DrivePal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = DistributionDrivePalProfile;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = DevDrivePalProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -818,7 +818,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = DrivePalWidgetExtension/DrivePalWidgetExtension.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -836,7 +836,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = pos.academy.DrivePal.DrivePalWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Distribution_DrivePal_Extension_Profile;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Dev_DrivePal_Extension_Profile;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/DrivePal.xcodeproj/xcshareddata/xcschemes/DrivePal.xcscheme
+++ b/DrivePal.xcodeproj/xcshareddata/xcschemes/DrivePal.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"

--- a/DrivePal/Sources/Model/Location/LocationsHandler.swift
+++ b/DrivePal/Sources/Model/Location/LocationsHandler.swift
@@ -31,6 +31,12 @@ final class LocationsHandler: NSObject, ObservableObject {
     
     @Published var authorizationStatus = AuthorizationStatus.inProgress
     
+    var isAnimated = false {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+    
     var motionStatus = MotionStatus.none {
         willSet {
             guard isWriteEnabled else { return }
@@ -105,8 +111,8 @@ extension LocationsHandler {
         }
         let kilometerPerHour = Int(round(speed * 3.6 * 10) / 10)    // 소숫점 한 자리에서 반올림 0.1 까지의 정확도, 1의 자리부터 표현
         speedModel = SpeedModel(date: current.timestamp,
-                            kilometerPerHour: kilometerPerHour,
-                            location: current)
+                                kilometerPerHour: kilometerPerHour,
+                                location: current)
     }
     
     func requestAuthorization() {
@@ -120,20 +126,24 @@ extension LocationsHandler {
     }
     
     private func sleepThreadBriefly() {
-        guard let locationManager else { return }
-        stopUpdateSpeed()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: updateSpeed)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            self.isAnimated = false
+            withAnimation { self.motionStatus = .normal }
+        }
     }
     
     private func adjustMotionStatus(by speed: Int) {
         guard motionStatus != .none else { return }
         guard motionStatus != .takingOff else { return }
+        guard !self.isAnimated else { return }
         if speed >= 11 {
+            isAnimated = true
             withAnimation { motionStatus = .suddenAcceleration }
             sleepThreadBriefly()
             logger.info("\(#function): Detact Sudden Acceleration")
             return
         } else if speed <= -7 {
+            isAnimated = true
             withAnimation { motionStatus = .suddenStop }
             sleepThreadBriefly()
             logger.info("\(#function): Detact Sudden Stop")

--- a/DrivePal/Sources/Model/Location/LocationsHandler.swift
+++ b/DrivePal/Sources/Model/Location/LocationsHandler.swift
@@ -31,7 +31,7 @@ final class LocationsHandler: NSObject, ObservableObject {
     
     @Published var authorizationStatus = AuthorizationStatus.inProgress
     
-    var isAnimated = false {
+    private var isAnimated = false {
         willSet {
             objectWillChange.send()
         }


### PR DESCRIPTION
📣 Assignees와 Labels를 우측에서 추가해 주세요!

# 📢 Description
개발한 기능이 무엇인지, 수정한 버그가 무엇인지 설명해주세요
- 애니메이션 중 컴포넌트들의 타이밍 맞췄습니다
- 다이나믹 아일랜드 (백그라운드)에서 업데이트 안되는 이슈 해결

# 🔑 Key Changes
### 중심적으로 변화가 있는 부분을 명시해 주세요
- 로케이션 업데이트를 중단하면서 발생하는 문제였습니다
- 일단은 부울 변수 하나 만들어서 급감가속이 찍힌 후 3초간 motionStatus의 값을 바꾸지 못하도록 했어요

# 📸 Screenshots
카톡으로 보냅니다

# 🙏 To Reviewers
달리는중 시작하면 시작하자마자 경고 해결하기가 까다로운 부분이었네요 이거 일단 넘어갑시다
신경쓰이는건 급감속을 연속 두번이상하거나 급가속을 연속으로 두 번 이상하면 번개애니메이션이 움직이지 않습니다
(급가속 후 급감속은 아마 해당 안될 것. 급가속 후 급가속하는 경우를 뜻함)
async deadline 타이밍이 꼬인 것 같은데, 아마 5초 내에 급가속을 연속 두 번 하는 상황이 드물것같아 일단 급한 불 먼저 끕니다
